### PR TITLE
Reduce noise computations for mobile textures

### DIFF
--- a/app/(home)/NoiseFilter.tsx
+++ b/app/(home)/NoiseFilter.tsx
@@ -15,8 +15,11 @@ export function NoiseFilter() {
         <filter id={svgIds.noiseFilter}>
           <feTurbulence
             type="fractalNoise"
-            baseFrequency="6.29"
-            numOctaves="6"
+            // We keep baseFrequency and numOctaves low because it seems to be
+            // too computationally expensive on mobile and the texture isn't
+            // fully rendered
+            baseFrequency="1.09"
+            numOctaves="1"
             stitchTiles="stitch"
           ></feTurbulence>
         </filter>


### PR DESCRIPTION
## Description

The texture appeared clipped on Chrome Android, and playing around with parameters it seems it was because the parameters for the perlin noise were too expensive to compute and just stopped

## Checklist

- [x] Cleaned up the branch commit history with `git rebase -i`, as needed
